### PR TITLE
Create getComponentType functions and helper functions

### DIFF
--- a/server/src/utilities/getComponentType/helpers/index.ts
+++ b/server/src/utilities/getComponentType/helpers/index.ts
@@ -1,0 +1,9 @@
+import isNgComponent from './isNgComponent';
+import isNgModule from './isNgModule';
+import isReact from './isReact';
+
+export default {
+  isNgComponent,
+  isNgModule,
+  isReact
+};

--- a/server/src/utilities/getComponentType/helpers/isNgComponent.test.ts
+++ b/server/src/utilities/getComponentType/helpers/isNgComponent.test.ts
@@ -1,0 +1,15 @@
+import isNgComponent from './isNgComponent';
+
+describe('isAngular.ts', () => {
+  it('should return false when fileContents is null', () => {
+    expect(isNgComponent(null)).toBeFalsy();
+  });
+
+  it('should return false when fileContents does not contain @Component or @Module', () => {
+    expect(isNgComponent('test')).toBeFalsy();
+  });
+
+  it('should return true when fileContents contains @Component', () => {
+    expect(isNgComponent('@Component')).toBeTruthy();
+  });
+});

--- a/server/src/utilities/getComponentType/helpers/isNgComponent.ts
+++ b/server/src/utilities/getComponentType/helpers/isNgComponent.ts
@@ -1,0 +1,11 @@
+function isNgComponent (fileContents: string): boolean {
+  let isNgComponent = false;
+
+  if (fileContents != null) {
+    isNgComponent = fileContents.indexOf('@Component') >= 0;
+  }
+
+  return isNgComponent;
+}
+
+export default isNgComponent;

--- a/server/src/utilities/getComponentType/helpers/isNgModule.test.ts
+++ b/server/src/utilities/getComponentType/helpers/isNgModule.test.ts
@@ -1,0 +1,15 @@
+import isNgModule from './isNgModule';
+
+describe('isAngular.ts', () => {
+  it('should return false when fileContents is null', () => {
+    expect(isNgModule(null)).toBeFalsy();
+  });
+
+  it('should return false when fileContents does not contain @Component or @Module', () => {
+    expect(isNgModule('test')).toBeFalsy();
+  });
+
+  it('should return true when fileContents contains @Module', () => {
+    expect(isNgModule('@NgModule')).toBeTruthy();
+  });
+});

--- a/server/src/utilities/getComponentType/helpers/isNgModule.ts
+++ b/server/src/utilities/getComponentType/helpers/isNgModule.ts
@@ -1,0 +1,11 @@
+function isNgModule (fileContents: string): boolean {
+  let isNgModule = false;
+
+  if (fileContents != null) {
+    isNgModule = fileContents.indexOf('@NgModule') >= 0;
+  }
+
+  return isNgModule;
+}
+
+export default isNgModule;

--- a/server/src/utilities/getComponentType/helpers/isReact.test.ts
+++ b/server/src/utilities/getComponentType/helpers/isReact.test.ts
@@ -1,0 +1,23 @@
+import isReact from './isReact';
+
+describe('isReact.ts', () => {
+  it('should return false when fileContents is null', () => {
+    expect(isReact(null)).toBeFalsy();
+  });
+
+  it('should return false when fileContents does not contain the React import from react', () => {
+    expect(isReact(`import { Component } from 'react'`)).toBeFalsy();
+  });
+
+  it('should return true when fileContents contains the React import from react', () => {
+    expect(isReact(`import React from 'react'`)).toBeTruthy();
+  });
+
+  it('should return true when fileContents contains the React import last from react', () => {
+    expect(isReact(`import { Component }, React from 'react'`)).toBeTruthy();
+  });
+
+  it('should return true when fileContents contains the React not last from react', () => {
+    expect(isReact(`import React, { Component } from 'react'`)).toBeTruthy();
+  });
+});

--- a/server/src/utilities/getComponentType/helpers/isReact.ts
+++ b/server/src/utilities/getComponentType/helpers/isReact.ts
@@ -5,8 +5,9 @@ function isReact (fileContents: string): boolean {
     const importIndex = fileContents.indexOf(`from 'react'`);
 
     if (importIndex > 0) {
-      hasReactImport = fileContents.substring(0, importIndex).indexOf(' React ') > 0
-        || fileContents.substring(0, importIndex).indexOf(' React,') > 0;
+      const importPortion = fileContents.substring(0, importIndex);
+      hasReactImport = importPortion.indexOf(' React ') > 0
+        || importPortion.indexOf(' React,') > 0;
     }
   }
 

--- a/server/src/utilities/getComponentType/helpers/isReact.ts
+++ b/server/src/utilities/getComponentType/helpers/isReact.ts
@@ -1,0 +1,16 @@
+function isReact (fileContents: string): boolean {
+  let hasReactImport = false;
+
+  if (fileContents != null) {
+    const importIndex = fileContents.indexOf(`from 'react'`);
+
+    if (importIndex > 0) {
+      hasReactImport = fileContents.substring(0, importIndex).indexOf(' React ') > 0
+        || fileContents.substring(0, importIndex).indexOf(' React,') > 0;
+    }
+  }
+
+  return hasReactImport;
+}
+
+export default isReact;

--- a/server/src/utilities/getComponentType/index.test.ts
+++ b/server/src/utilities/getComponentType/index.test.ts
@@ -1,0 +1,40 @@
+import getComponentType from '.';
+import helpers from './helpers';
+
+describe('index.ts', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return null when the input does not return true for any framework', () => {
+    helpers.isNgComponent = jest.fn(() => false);
+    helpers.isNgModule = jest.fn(() => false);
+    helpers.isReact = jest.fn(() => false);
+    const framework = getComponentType('test');
+    expect(framework).toBeNull();
+  });
+
+  it('should return ngComponent when isNgComponent is true', () => {
+    helpers.isNgComponent = jest.fn(() => true);
+    helpers.isNgModule = jest.fn(() => false);
+    helpers.isReact = jest.fn(() => false);
+    const framework = getComponentType('test');
+    expect(framework).toBe('ngComponent');
+  });
+
+  it('should return ngModule when isNgModule is true', () => {
+    helpers.isNgComponent = jest.fn(() => false);
+    helpers.isNgModule = jest.fn(() => true);
+    helpers.isReact = jest.fn(() => false);
+    const framework = getComponentType('test');
+    expect(framework).toBe('ngModule');
+  });
+
+  it('should return react when isReact is true', () => {
+    helpers.isNgComponent = jest.fn(() => false);
+    helpers.isNgModule = jest.fn(() => false);
+    helpers.isReact = jest.fn(() => true);
+    const framework = getComponentType('test');
+    expect(framework).toBe('react');
+  });
+});

--- a/server/src/utilities/getComponentType/index.ts
+++ b/server/src/utilities/getComponentType/index.ts
@@ -1,0 +1,17 @@
+import helpers from './helpers';
+
+function getComponentType (fileContents: string): string {
+  let componentType = null;
+
+  if (helpers.isNgComponent(fileContents)) {
+    componentType = 'ngComponent';
+  } else if (helpers.isNgModule(fileContents)) {
+    componentType = 'ngModule';
+  } else if (helpers.isReact(fileContents)) {
+    componentType = 'react';
+  }
+
+  return componentType;
+}
+
+export default getComponentType;


### PR DESCRIPTION
This adds a function that takes the contents of a file as a string and outputs whether or not it is an ngComponent, ngModule, or react component. AngularJs isn't currently supported, but it would be relatively easy to implement a similar isAngularjs check.